### PR TITLE
[ENG-4168] Refactor the chunk response API

### DIFF
--- a/src/main/java/co/cask/http/AbstractHttpResponder.java
+++ b/src/main/java/co/cask/http/AbstractHttpResponder.java
@@ -17,7 +17,6 @@
 package co.cask.http;
 
 import com.google.common.base.Charsets;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -35,7 +34,7 @@ import java.nio.ByteBuffer;
 import javax.annotation.Nullable;
 
 /**
- * Base implementation of {@link HttpResponder} to simplifies children implementation.
+ * Base implementation of {@link HttpResponder} to simplifies child implementations.
  */
 public abstract class AbstractHttpResponder implements HttpResponder {
 
@@ -105,10 +104,7 @@ public abstract class AbstractHttpResponder implements HttpResponder {
   }
 
   @Override
-  public void sendError(HttpResponseStatus status, String errorMessage) {
-    Preconditions.checkArgument(!status.equals(HttpResponseStatus.OK), "Response status cannot be OK for errors");
-
-    ChannelBuffer errorContent = ChannelBuffers.wrappedBuffer(Charsets.UTF_8.encode(errorMessage));
-    sendContent(status, errorContent, "text/plain; charset=utf-8", ImmutableMultimap.<String, String>of());
+  public final void sendError(HttpResponseStatus status, String errorMessage) {
+    sendString(status, errorMessage);
   }
 }

--- a/src/main/java/co/cask/http/AbstractHttpResponder.java
+++ b/src/main/java/co/cask/http/AbstractHttpResponder.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.http;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonWriter;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBufferOutputStream;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
+import javax.annotation.Nullable;
+
+/**
+ * Base implementation of {@link HttpResponder} to simplifies children implementation.
+ */
+public abstract class AbstractHttpResponder implements HttpResponder {
+
+  private static final Gson GSON = new Gson();
+
+  @Override
+  public void sendJson(HttpResponseStatus status, Object object) {
+    sendJson(status, object, object.getClass());
+  }
+
+  @Override
+  public void sendJson(HttpResponseStatus status, Object object, Type type) {
+    sendJson(status, object, type, GSON);
+  }
+
+  @Override
+  public void sendJson(HttpResponseStatus status, Object object, Type type, Gson gson) {
+    try {
+      ChannelBuffer channelBuffer = ChannelBuffers.dynamicBuffer();
+      JsonWriter jsonWriter = new JsonWriter(new OutputStreamWriter(new ChannelBufferOutputStream(channelBuffer),
+                                                                    Charsets.UTF_8));
+      try {
+        gson.toJson(object, type, jsonWriter);
+      } finally {
+        jsonWriter.close();
+      }
+
+      sendContent(status, channelBuffer, "application/json", ImmutableMultimap.<String, String>of());
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void sendString(HttpResponseStatus status, String data) {
+    if (data == null) {
+      sendStatus(status);
+      return;
+    }
+    try {
+      ChannelBuffer channelBuffer = ChannelBuffers.wrappedBuffer(Charsets.UTF_8.encode(data));
+      sendContent(status, channelBuffer, "text/plain; charset=utf-8", ImmutableMultimap.<String, String>of());
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void sendStatus(HttpResponseStatus status) {
+    sendContent(status, null, null, ImmutableMultimap.<String, String>of());
+  }
+
+  @Override
+  public void sendStatus(HttpResponseStatus status, @Nullable Multimap<String, String> headers) {
+    sendContent(status, null, null, headers);
+  }
+
+  @Override
+  public void sendByteArray(HttpResponseStatus status, byte[] bytes, @Nullable Multimap<String, String> headers) {
+    ChannelBuffer channelBuffer = ChannelBuffers.wrappedBuffer(bytes);
+    sendContent(status, channelBuffer, "application/octet-stream", headers);
+  }
+
+  @Override
+  public void sendBytes(HttpResponseStatus status, ByteBuffer buffer, @Nullable Multimap<String, String> headers) {
+    sendContent(status, ChannelBuffers.wrappedBuffer(buffer), "application/octet-stream", headers);
+  }
+
+  @Override
+  public void sendError(HttpResponseStatus status, String errorMessage) {
+    Preconditions.checkArgument(!status.equals(HttpResponseStatus.OK), "Response status cannot be OK for errors");
+
+    ChannelBuffer errorContent = ChannelBuffers.wrappedBuffer(Charsets.UTF_8.encode(errorMessage));
+    sendContent(status, errorContent, "text/plain; charset=utf-8", ImmutableMultimap.<String, String>of());
+  }
+}

--- a/src/main/java/co/cask/http/BasicHttpResponder.java
+++ b/src/main/java/co/cask/http/BasicHttpResponder.java
@@ -16,24 +16,16 @@
 
 package co.cask.http;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
-import com.google.gson.Gson;
-import com.google.gson.stream.JsonWriter;
 import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBufferOutputStream;
-import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelFuture;
 import org.jboss.netty.channel.ChannelFutureListener;
 import org.jboss.netty.channel.ChannelFutureProgressListener;
 import org.jboss.netty.channel.DefaultFileRegion;
 import org.jboss.netty.channel.FileRegion;
-import org.jboss.netty.handler.codec.http.DefaultHttpChunk;
-import org.jboss.netty.handler.codec.http.DefaultHttpChunkTrailer;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpResponse;
@@ -42,165 +34,34 @@ import org.jboss.netty.handler.codec.http.HttpVersion;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.io.RandomAccessFile;
-import java.lang.reflect.Type;
-import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
 
 /**
  * HttpResponder responds back to the client that initiated the request. Caller can use sendJson method to respond
  * back to the client in json format.
  */
-public class BasicHttpResponder implements HttpResponder {
+public class BasicHttpResponder extends AbstractHttpResponder {
+
   private final Channel channel;
-  private final boolean keepalive;
+  private final boolean keepAlive;
   private final AtomicBoolean responded;
 
-  private final ThreadLocal<Gson> gson = new ThreadLocal<Gson>() {
-    @Override
-    protected Gson initialValue() {
-      return new Gson();
-    }
-  };
-
-  public BasicHttpResponder(Channel channel, boolean keepalive) {
+  public BasicHttpResponder(Channel channel, boolean keepAlive) {
     this.channel = channel;
-    this.keepalive = keepalive;
+    this.keepAlive = keepAlive;
     responded = new AtomicBoolean(false);
   }
 
-  /**
-   * Sends json response back to the client.
-   * @param status Status of the response.
-   * @param object Object that will be serialized into Json and sent back as content.
-   */
   @Override
-  public void sendJson(HttpResponseStatus status, Object object) {
-    sendJson(status, object, object.getClass());
-  }
-
-  /**
-   * Sends json response back to the client.
-   * @param status Status of the response.
-   * @param object Object that will be serialized into Json and sent back as content.
-   * @param type Type of object.
-   */
-  @Override
-  public void sendJson(HttpResponseStatus status, Object object, Type type) {
-    sendJson(status, object, type, gson.get());
-  }
-
-  /**
-   * Sends json response back to the client using the given gson object.
-   * @param status Status of the response.
-   * @param object Object that will be serialized into Json and sent back as content.
-   * @param type Type of object.
-   * @param gson Gson object for serialization.
-   */
-  @Override
-  public void sendJson(HttpResponseStatus status, Object object, Type type, Gson gson) {
-    try {
-      ChannelBuffer channelBuffer = ChannelBuffers.dynamicBuffer();
-      JsonWriter jsonWriter = new JsonWriter(new OutputStreamWriter(new ChannelBufferOutputStream(channelBuffer),
-                                                                    Charsets.UTF_8));
-      try {
-        gson.toJson(object, type, jsonWriter);
-      } finally {
-        jsonWriter.close();
-      }
-
-      sendContent(status, channelBuffer, "application/json", ImmutableMultimap.<String, String>of());
-    } catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
-  }
-
-  /**
-   * Send a string response back to the http client.
-   * @param status status of the Http response.
-   * @param data string data to be sent back.
-   */
-  @Override
-  public void sendString(HttpResponseStatus status, String data) {
-    if (data == null) {
-      sendStatus(status);
-    }
-    try {
-      ChannelBuffer channelBuffer = ChannelBuffers.wrappedBuffer(Charsets.UTF_8.encode(data));
-      sendContent(status, channelBuffer, "text/plain; charset=utf-8", ImmutableMultimap.<String, String>of());
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
-  }
-
-  /**
-   * Send only a status code back to client without any content.
-   * @param status status of the Http response.
-   */
-  @Override
-  public void sendStatus(HttpResponseStatus status) {
-    sendContent(status, null, null, ImmutableMultimap.<String, String>of());
-  }
-
-  @Override
-  public void sendStatus(HttpResponseStatus status, Multimap<String, String> headers) {
-    sendContent(status, null, null, headers);
-  }
-
-  /**
-   * Send a response containing raw bytes. Sets "application/octet-stream" as content type header.
-   * @param status status of the Http response.
-   * @param bytes bytes to be sent back.
-   * @param headers headers to be sent back. This will overwrite any headers set by the framework.
-   */
-  @Override
-  public void sendByteArray(HttpResponseStatus status, byte[] bytes, Multimap<String, String> headers) {
-    ChannelBuffer channelBuffer = ChannelBuffers.wrappedBuffer(bytes);
-    sendContent(status, channelBuffer, "application/octet-stream", headers);
-  }
-
-  /**
-   * Sends a response containing raw bytes. Default content type is "application/octet-stream", but can be
-   * overridden in the headers.
-   * @param status status of the Http response
-   * @param buffer bytes to send
-   * @param headers Headers to send.
-   */
-  @Override
-  public void sendBytes(HttpResponseStatus status, ByteBuffer buffer, Multimap<String, String> headers) {
-    sendContent(status, ChannelBuffers.wrappedBuffer(buffer), "application/octet-stream", headers);
-  }
-
-  /**
-   * Sends error message back to the client.
-   *
-   * @param status Status of the response.
-   * @param errorMessage Error message sent back to the client.
-   */
-  @Override
-  public void sendError(HttpResponseStatus status, String errorMessage) {
-    Preconditions.checkArgument(!status.equals(HttpResponseStatus.OK), "Response status cannot be OK for errors");
-
-    ChannelBuffer errorContent = ChannelBuffers.wrappedBuffer(Charsets.UTF_8.encode(errorMessage));
-    sendContent(status, errorContent, "text/plain; charset=utf-8", ImmutableMultimap.<String, String>of());
-  }
-
-  /**
-   * Respond to the client saying the response will be in chunks. Add chunks to response using
- *  {@link #sendChunk(ChannelBuffer)} and {@link #sendChunkEnd}.
-   * @param status  the status code to respond with. Defaults to 200-OK if null.
-   * @param headers additional headers to send with the response. May be null.
-   */
-  @Override
-  public void sendChunkStart(HttpResponseStatus status, Multimap<String, String> headers) {
+  public ChunkResponder sendChunkStart(HttpResponseStatus status, @Nullable Multimap<String, String> headers) {
     Preconditions.checkArgument(responded.compareAndSet(false, true), "Response has been already sent");
     Preconditions.checkArgument((status.getCode() >= 200 && status.getCode() < 210) , "Http Chunk Failure");
-    HttpResponse response = new DefaultHttpResponse(
-      HttpVersion.HTTP_1_1, status != null ? status : HttpResponseStatus.OK);
+    HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
 
     if (headers != null) {
       for (Map.Entry<String, Collection<String>> entry : headers.asMap().entrySet()) {
@@ -210,42 +71,16 @@ public class BasicHttpResponder implements HttpResponder {
 
     response.setChunked(true);
     response.setHeader(HttpHeaders.Names.TRANSFER_ENCODING, HttpHeaders.Values.CHUNKED);
-    channel.write(response);
-
-  }
-
-  /**
-   * Add a chunk of data to the response. {@link #sendChunkStart(HttpResponseStatus, Multimap)}
-   * should be called before calling this method. {@link #sendChunkEnd} should be called after all chunks are done.
-   * @param content the chunk of content to send
-   */
-  @Override
-  public void sendChunk(ChannelBuffer content) {
-    channel.write(new DefaultHttpChunk(content));
-  }
-
-  /**
-   * Called after all chunks are done. This keeps the connection alive
-   * unless specified otherwise in the original request.
-   */
-  @Override
-  public void sendChunkEnd() {
-    ChannelFuture future = channel.write(new DefaultHttpChunkTrailer());
-    if (!keepalive) {
-      future.addListener(ChannelFutureListener.CLOSE);
+    if (keepAlive) {
+      response.setHeader(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
     }
+    channel.write(response);
+    return new ChannelChunkResponder(channel, keepAlive);
   }
 
-  /**
-   * Send response back to client.
-   * @param status Status of the response.
-   * @param content Content to be sent back.
-   * @param contentType Type of content.
-   * @param headers Headers to be sent back.
-   */
   @Override
-  public void sendContent(HttpResponseStatus status, ChannelBuffer content, String contentType,
-                          Multimap<String, String> headers) {
+  public void sendContent(HttpResponseStatus status, @Nullable ChannelBuffer content, String contentType,
+                          @Nullable Multimap<String, String> headers) {
     Preconditions.checkArgument(responded.compareAndSet(false, true), "Response has been already sent");
     HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
 
@@ -257,7 +92,7 @@ public class BasicHttpResponder implements HttpResponder {
       response.setHeader(HttpHeaders.Names.CONTENT_LENGTH, 0);
     }
 
-    if (keepalive) {
+    if (keepAlive) {
       response.setHeader(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
     }
 
@@ -269,19 +104,19 @@ public class BasicHttpResponder implements HttpResponder {
     }
 
     ChannelFuture future = channel.write(response);
-    if (!keepalive || status.getCode() >= 400) {
+    if (!keepAlive || status.getCode() >= 400) {
       future.addListener(ChannelFutureListener.CLOSE);
     }
   }
 
   @Override
-  public void sendFile(File file, Multimap<String, String> headers) {
+  public void sendFile(File file, @Nullable Multimap<String, String> headers) {
     Preconditions.checkArgument(responded.compareAndSet(false, true), "Response has been already sent");
     HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
 
     response.setHeader(HttpHeaders.Names.CONTENT_LENGTH, file.length());
 
-    if (keepalive) {
+    if (keepAlive) {
       response.setHeader(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
     }
 
@@ -306,7 +141,7 @@ public class BasicHttpResponder implements HttpResponder {
       writeFuture.addListener(new ChannelFutureProgressListener() {
         public void operationComplete(ChannelFuture future) {
           region.releaseExternalResources();
-          if (!keepalive) {
+          if (!keepAlive) {
             channel.close();
           }
         }

--- a/src/main/java/co/cask/http/ChannelChunkResponder.java
+++ b/src/main/java/co/cask/http/ChannelChunkResponder.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.http;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelFuture;
+import org.jboss.netty.channel.ChannelFutureListener;
+import org.jboss.netty.handler.codec.http.DefaultHttpChunk;
+import org.jboss.netty.handler.codec.http.DefaultHttpChunkTrailer;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A {@link ChunkResponder} that writes chunks to a {@link Channel}.
+ */
+final class ChannelChunkResponder implements ChunkResponder {
+
+  private final Channel channel;
+  private final boolean keepAlive;
+  private final AtomicBoolean closed;
+
+  ChannelChunkResponder(Channel channel, boolean keepAlive) {
+    this.channel = channel;
+    this.keepAlive = keepAlive;
+    this.closed = new AtomicBoolean(false);
+  }
+
+  @Override
+  public void sendChunk(ByteBuffer chunk) throws IOException {
+    sendChunk(ChannelBuffers.wrappedBuffer(chunk));
+  }
+
+  @Override
+  public void sendChunk(ChannelBuffer chunk) throws IOException {
+    if (closed.get()) {
+      throw new IOException("ChunkResponder already closed.");
+    }
+    if (!channel.isConnected()) {
+      throw new IOException("Connection already closed.");
+    }
+    channel.write(new DefaultHttpChunk(chunk));
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (!closed.compareAndSet(false, true)) {
+      return;
+    }
+    ChannelFuture future = channel.write(new DefaultHttpChunkTrailer());
+    if (!keepAlive) {
+      future.addListener(ChannelFutureListener.CLOSE);
+    }
+  }
+}

--- a/src/main/java/co/cask/http/ChunkResponder.java
+++ b/src/main/java/co/cask/http/ChunkResponder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.http;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * A responder for sending chunk-encoded response
+ */
+public interface ChunkResponder extends Closeable {
+
+  /**
+   * Adds a chunk of data to the response. The content will be sent to the client asynchronously.
+   *
+   * @param chunk content to send
+   * @throws IOException if the connection is already closed
+   */
+  void sendChunk(ByteBuffer chunk) throws IOException;
+
+  /**
+   * Adds a chunk of data to the response. The content will be sent to the client asynchronously.
+   *
+   * @param chunk content to send
+   * @throws IOException if this {@link ChunkResponder} already closed or the connection is closed
+   */
+  void sendChunk(ChannelBuffer chunk) throws IOException;
+
+  /**
+   * Closes this responder which signals the end of the chunk response.
+   */
+  @Override
+  void close() throws IOException;
+}

--- a/src/main/java/co/cask/http/HttpResponder.java
+++ b/src/main/java/co/cask/http/HttpResponder.java
@@ -24,6 +24,7 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import java.io.File;
 import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
+import javax.annotation.Nullable;
 
 /**
  * HttpResponder is used to send response back to clients.
@@ -78,7 +79,7 @@ public interface HttpResponder {
    * @param status status of the Http response.
    * @param headers Headers to send.
    */
-  void sendStatus(HttpResponseStatus status, Multimap<String, String> headers);
+  void sendStatus(HttpResponseStatus status, @Nullable Multimap<String, String> headers);
 
   /**
    * Send a response containing raw bytes. Sets "application/octet-stream" as content type header.
@@ -87,7 +88,7 @@ public interface HttpResponder {
    * @param bytes bytes to be sent back.
    * @param headers headers to be sent back. This will overwrite any headers set by the framework.
    */
-  void sendByteArray(HttpResponseStatus status, byte[] bytes, Multimap<String, String> headers);
+  void sendByteArray(HttpResponseStatus status, byte[] bytes, @Nullable Multimap<String, String> headers);
 
   /**
    * Sends a response containing raw bytes. Default content type is "application/octet-stream", but can be
@@ -97,7 +98,7 @@ public interface HttpResponder {
    * @param buffer bytes to send
    * @param headers Headers to send.
    */
-  void sendBytes(HttpResponseStatus status, ByteBuffer buffer, Multimap<String, String> headers);
+  void sendBytes(HttpResponseStatus status, ByteBuffer buffer, @Nullable Multimap<String, String> headers);
 
   /**
    * Sends error message back to the client.
@@ -108,27 +109,13 @@ public interface HttpResponder {
   void sendError(HttpResponseStatus status, String errorMessage);
 
   /**
-   * Respond to the client saying the response will be in chunks. Add chunks to response using
-   * {@link #sendChunk(ChannelBuffer)} and {@link #sendChunkEnd}.
+   * Respond to the client saying the response will be in chunks. The response body can be sent in chunks
+   * using the {@link ChunkResponder} returned.
    *
    * @param status  the status code to respond with. Defaults to 200-OK if null.
    * @param headers additional headers to send with the response. May be null.
    */
-  void sendChunkStart(HttpResponseStatus status, Multimap<String, String> headers);
-
-  /**
-   * Add a chunk of data to the response. {@link #sendChunkStart(HttpResponseStatus, Multimap)}
-   * should be called before calling this method. {@link #sendChunkEnd} should be called after all chunks are done.
-   *
-   * @param content the chunk of content to send
-   */
-  void sendChunk(ChannelBuffer content);
-
-  /**
-   * Called after all chunks are done. This keeps the connection alive
-   * unless specified otherwise in the original request.
-   */
-  void sendChunkEnd();
+  ChunkResponder sendChunkStart(HttpResponseStatus status, @Nullable Multimap<String, String> headers);
 
   /**
    * Send response back to client.
@@ -139,14 +126,14 @@ public interface HttpResponder {
    * @param headers Headers to be sent back.
    */
   void sendContent(HttpResponseStatus status, ChannelBuffer content, String contentType,
-                   Multimap<String, String> headers);
+                   @Nullable Multimap<String, String> headers);
 
 
   /**
-   * Sends a file content back to client.
+   * Sends a file content back to client with response status 200.
    *
-   * @param file
-   * @param headers
+   * @param file The file to send
+   * @param headers Headers to be sent back.
    */
-  void sendFile(File file, Multimap<String, String> headers);
+  void sendFile(File file, @Nullable Multimap<String, String> headers);
 }

--- a/src/main/java/co/cask/http/HttpResponder.java
+++ b/src/main/java/co/cask/http/HttpResponder.java
@@ -105,14 +105,17 @@ public interface HttpResponder {
    *
    * @param status Status of the response.
    * @param errorMessage Error message sent back to the client.
+   *
+   * @deprecated Same as calling {@link #sendString(org.jboss.netty.handler.codec.http.HttpResponseStatus, String)}
    */
+  @Deprecated
   void sendError(HttpResponseStatus status, String errorMessage);
 
   /**
    * Respond to the client saying the response will be in chunks. The response body can be sent in chunks
    * using the {@link ChunkResponder} returned.
    *
-   * @param status  the status code to respond with. Defaults to 200-OK if null.
+   * @param status  the status code to respond with
    * @param headers additional headers to send with the response. May be null.
    */
   ChunkResponder sendChunkStart(HttpResponseStatus status, @Nullable Multimap<String, String> headers);

--- a/src/main/java/co/cask/http/InternalHttpResponder.java
+++ b/src/main/java/co/cask/http/InternalHttpResponder.java
@@ -16,14 +16,9 @@
 
 package co.cask.http;
 
-import com.google.common.base.Charsets;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
-import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import com.google.common.io.InputSupplier;
-import com.google.gson.Gson;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBufferInputStream;
 import org.jboss.netty.buffer.ChannelBuffers;
@@ -32,126 +27,80 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
-import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * InternalHttpResponder is used when a handler is being called internally by some other handler, and thus there
  * is no need to go through the network.  It stores the status code and content in memory and returns them when asked.
  */
-public class InternalHttpResponder implements HttpResponder {
+public class InternalHttpResponder extends AbstractHttpResponder {
+
   private int statusCode;
-  private List<ChannelBuffer> contentChunks;
   private InputSupplier<? extends InputStream> inputSupplier;
 
-  private static final Gson gson = new Gson();
-
   public InternalHttpResponder() {
-    contentChunks = Lists.newLinkedList();
     statusCode = 0;
   }
 
   @Override
-  public void sendJson(HttpResponseStatus status, Object object) {
-    sendJson(status, object, object.getClass());
-  }
-
-  @Override
-  public void sendJson(HttpResponseStatus status, Object object, Type type) {
-    sendJson(status, object, type, gson);
-  }
-
-  @Override
-  public void sendJson(HttpResponseStatus status, Object object, Type type, Gson gson) {
-    setResponseContent(status, gson.toJson(object, type).getBytes(Charsets.UTF_8));
-  }
-
-  @Override
-  public void sendString(HttpResponseStatus status, String data) {
-    if (data == null) {
-      sendStatus(status);
-    } else {
-      setResponseContent(status, data.getBytes(Charsets.UTF_8));
-    }
-  }
-
-  @Override
-  public void sendStatus(HttpResponseStatus status) {
+  public ChunkResponder sendChunkStart(HttpResponseStatus status, @Nullable Multimap<String, String> headers) {
     statusCode = status.getCode();
-  }
+    return new ChunkResponder() {
 
-  @Override
-  public void sendStatus(HttpResponseStatus status, Multimap<String, String> headers) {
-    statusCode = status.getCode();
-  }
+      private ChannelBuffer contentChunks = ChannelBuffers.EMPTY_BUFFER;
+      private boolean closed;
 
-  @Override
-  public void sendByteArray(HttpResponseStatus status, byte[] bytes, Multimap<String, String> headers) {
-    setResponseContent(status, bytes);
-  }
-
-  @Override
-  public void sendBytes(HttpResponseStatus status, ByteBuffer buffer, Multimap<String, String> headers) {
-    byte[] bytes = new byte[buffer.remaining()];
-    int position = buffer.position();
-    buffer.get(bytes);
-    buffer.position(position);
-    setResponseContent(status, bytes);
-  }
-
-  @Override
-  public void sendError(HttpResponseStatus status, String errorMessage) {
-    Preconditions.checkArgument(!status.equals(HttpResponseStatus.OK), "Response status cannot be OK for errors");
-
-    setResponseContent(status, errorMessage.getBytes(Charsets.UTF_8));
-  }
-
-  @Override
-  public void sendChunkStart(HttpResponseStatus status, Multimap<String, String> headers) {
-    statusCode = status.getCode();
-    contentChunks.clear();
-  }
-
-  @Override
-  public void sendChunk(ChannelBuffer content) {
-    contentChunks.add(content);
-  }
-
-  @Override
-  public void sendChunkEnd() {
-    ChannelBuffer[] chunks = new ChannelBuffer[contentChunks.size()];
-    contentChunks.toArray(chunks);
-    final ChannelBuffer body = ChannelBuffers.wrappedBuffer(chunks);
-    body.markReaderIndex();
-
-    inputSupplier = new InputSupplier<InputStream>() {
       @Override
-      public InputStream getInput() throws IOException {
-        body.resetReaderIndex();
-        return new ChannelBufferInputStream(body);
+      public void sendChunk(ByteBuffer chunk) throws IOException {
+        sendChunk(ChannelBuffers.wrappedBuffer(chunk));
+      }
+
+      @Override
+      public synchronized void sendChunk(ChannelBuffer chunk) throws IOException {
+        if (closed) {
+          throw new IOException("ChunkResponder already closed.");
+        }
+        contentChunks = ChannelBuffers.wrappedBuffer(contentChunks, chunk);
+      }
+
+      @Override
+      public synchronized void close() throws IOException {
+        if (closed) {
+          return;
+        }
+        closed = true;
+        inputSupplier = createContentSupplier(contentChunks);
       }
     };
   }
 
   @Override
-  public void sendContent(HttpResponseStatus status, ChannelBuffer content, String contentType,
-                          Multimap<String, String> headers) {
-    setResponseContent(status, content.array());
-  }
-
-  private void setResponseContent(HttpResponseStatus status, byte[] content) {
+  public void sendContent(HttpResponseStatus status, @Nullable ChannelBuffer content, String contentType,
+                          @Nullable Multimap<String, String> headers) {
     statusCode = status.getCode();
-    inputSupplier = ByteStreams.newInputStreamSupplier(content);
+    inputSupplier = createContentSupplier(content == null ? ChannelBuffers.EMPTY_BUFFER : content);
   }
 
   @Override
-  public void sendFile(File file, Multimap<String, String> headers) {
+  public void sendFile(File file, @Nullable Multimap<String, String> headers) {
     statusCode = HttpResponseStatus.OK.getCode();
     inputSupplier = Files.newInputStreamSupplier(file);
   }
 
   public InternalHttpResponse getResponse() {
     return new BasicInternalHttpResponse(statusCode, inputSupplier);
+  }
+
+  private InputSupplier<InputStream> createContentSupplier(ChannelBuffer content) {
+    final ChannelBuffer responseContent = content.duplicate();    // Have independent pointers.
+    responseContent.markReaderIndex();
+    return new InputSupplier<InputStream>() {
+      @Override
+      public InputStream getInput() throws IOException {
+        responseContent.resetReaderIndex();
+        return new ChannelBufferInputStream(responseContent);
+      }
+    };
   }
 }

--- a/src/test/java/co/cask/http/HttpServerTest.java
+++ b/src/test/java/co/cask/http/HttpServerTest.java
@@ -361,6 +361,18 @@ public class HttpServerTest {
     testContent("/test/v1/multi-match/foo", "multi-match-put-actual-foo", HttpMethod.PUT);
   }
 
+  @Test
+  public void testChunkResponse() throws IOException {
+    HttpURLConnection urlConn = request("/test/v1/chunk", HttpMethod.POST);
+    try {
+      writeContent(urlConn, "Testing message");
+      String response = getContent(urlConn);
+      System.out.println(response);
+    } finally {
+      urlConn.disconnect();
+    }
+  }
+
   protected void testContent(String path, String content) throws IOException {
     testContent(path, content, HttpMethod.GET);
   }

--- a/src/test/java/co/cask/http/HttpServerTest.java
+++ b/src/test/java/co/cask/http/HttpServerTest.java
@@ -247,7 +247,6 @@ public class HttpServerTest {
     HttpURLConnection urlConn = request("/test/v1/tweets/1", HttpMethod.PUT, true);
     writeContent(urlConn, "data");
     Assert.assertEquals(200, urlConn.getResponseCode());
-    System.out.println(urlConn.getHeaderField(HttpHeaders.Names.CONNECTION));
 
     Assert.assertEquals("keep-alive", urlConn.getHeaderField(HttpHeaders.Names.CONNECTION));
     urlConn.disconnect();
@@ -367,7 +366,7 @@ public class HttpServerTest {
     try {
       writeContent(urlConn, "Testing message");
       String response = getContent(urlConn);
-      System.out.println(response);
+      Assert.assertEquals("Testing message", response);
     } finally {
       urlConn.disconnect();
     }

--- a/src/test/java/co/cask/http/InternalHttpResponderTest.java
+++ b/src/test/java/co/cask/http/InternalHttpResponderTest.java
@@ -84,11 +84,11 @@ public class InternalHttpResponderTest {
   @Test
   public void testChunks() throws IOException {
     InternalHttpResponder responder = new InternalHttpResponder();
-    responder.sendChunkStart(HttpResponseStatus.OK, HashMultimap.<String, String>create());
-    responder.sendChunk(ChannelBuffers.wrappedBuffer("a".getBytes(Charsets.UTF_8)));
-    responder.sendChunk(ChannelBuffers.wrappedBuffer("b".getBytes(Charsets.UTF_8)));
-    responder.sendChunk(ChannelBuffers.wrappedBuffer("c".getBytes(Charsets.UTF_8)));
-    responder.sendChunkEnd();
+    ChunkResponder chunkResponder = responder.sendChunkStart(HttpResponseStatus.OK, null);
+    chunkResponder.sendChunk(ChannelBuffers.wrappedBuffer("a".getBytes(Charsets.UTF_8)));
+    chunkResponder.sendChunk(ChannelBuffers.wrappedBuffer("b".getBytes(Charsets.UTF_8)));
+    chunkResponder.sendChunk(ChannelBuffers.wrappedBuffer("c".getBytes(Charsets.UTF_8)));
+    chunkResponder.close();
 
     validateResponse(responder.getResponse(), HttpResponseStatus.OK, "abc");
   }

--- a/src/test/java/co/cask/http/TestHandler.java
+++ b/src/test/java/co/cask/http/TestHandler.java
@@ -275,6 +275,18 @@ public class TestHandler implements HttpHandler {
     response.sendString(HttpResponseStatus.OK, "Uploaded:" + bytesUploaded);
   }
 
+  @Path("/chunk")
+  @POST
+  public void chunk(HttpRequest request, HttpResponder responder) throws IOException {
+    // Echo the POST body of size 1 byte chunk
+    ChannelBuffer content = request.getContent();
+    ChunkResponder chunker = responder.sendChunkStart(HttpResponseStatus.OK, null);
+    while (content.readable()) {
+      chunker.sendChunk(content.readSlice(1));
+    }
+    chunker.close();
+  }
+
 
   @Path("/uexception")
   @GET


### PR DESCRIPTION
- Returns a ChunkResponse on start chunk to make state management cleaner
- Refactor multiple implementations of HttpResponder with an abstract base
- Use @Nullable to annotation arguments that can be null
- Bug fixes.
