### PR TITLE
Honor “Connection: close” setting from the response header

### DIFF
--- a/src/main/java/co/cask/http/AbstractHttpResponder.java
+++ b/src/main/java/co/cask/http/AbstractHttpResponder.java
@@ -70,13 +70,18 @@ public abstract class AbstractHttpResponder implements HttpResponder {
 
   @Override
   public void sendString(HttpResponseStatus status, String data) {
+    sendString(status, data, null);
+  }
+
+  @Override
+  public void sendString(HttpResponseStatus status, String data, @Nullable Multimap<String, String> headers) {
     if (data == null) {
-      sendStatus(status);
+      sendStatus(status, headers);
       return;
     }
     try {
       ChannelBuffer channelBuffer = ChannelBuffers.wrappedBuffer(Charsets.UTF_8.encode(data));
-      sendContent(status, channelBuffer, "text/plain; charset=utf-8", ImmutableMultimap.<String, String>of());
+      sendContent(status, channelBuffer, "text/plain; charset=utf-8", headers);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }

--- a/src/main/java/co/cask/http/HttpResponder.java
+++ b/src/main/java/co/cask/http/HttpResponder.java
@@ -67,6 +67,15 @@ public interface HttpResponder {
   void sendString(HttpResponseStatus status, String data);
 
   /**
+   * Send a string response back to the http client.
+   *
+   * @param status status of the Http response.
+   * @param data string data to be sent back.
+   * @param headers Headers to send.
+   */
+  void sendString(HttpResponseStatus status, String data, @Nullable Multimap<String, String> headers);
+
+  /**
    * Send only a status code back to client without any content.
    *
    * @param status status of the Http response.

--- a/src/main/java/co/cask/http/WrappedHttpResponder.java
+++ b/src/main/java/co/cask/http/WrappedHttpResponder.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
+import javax.annotation.Nullable;
 
 /**
  * Wrap HttpResponder to call post handler hook.
@@ -70,6 +71,12 @@ final class WrappedHttpResponder implements HttpResponder {
   @Override
   public void sendString(HttpResponseStatus status, String data) {
     delegate.sendString(status, data);
+    runHook(status);
+  }
+
+  @Override
+  public void sendString(HttpResponseStatus status, String data, @Nullable Multimap<String, String> headers) {
+    delegate.sendString(status, data, headers);
     runHook(status);
   }
 

--- a/src/test/java/co/cask/http/HttpsServerTest.java
+++ b/src/test/java/co/cask/http/HttpsServerTest.java
@@ -31,12 +31,15 @@ import org.junit.BeforeClass;
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.Socket;
 import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Test the HttpsServer.
@@ -108,6 +111,11 @@ public class HttpsServerTest extends HttpServerTest {
       urlConn.setRequestProperty(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.CLOSE);
     }
     return urlConn;
+  }
+
+  @Override
+  protected Socket createRawSocket(URL url) throws IOException {
+    return sslClientContext.getClientContext().getSocketFactory().createSocket(url.getHost(), url.getPort());
   }
 
   public static void setSslClientContext(SSLClientContext sslClientContext) {

--- a/src/test/java/co/cask/http/TestHandler.java
+++ b/src/test/java/co/cask/http/TestHandler.java
@@ -20,6 +20,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -334,6 +335,19 @@ public class TestHandler implements HttpHandler {
     response.add("hobby", GSON.toJsonTree(hobbies, new TypeToken<List<String>>() { }.getType()));
 
     responder.sendJson(HttpResponseStatus.OK, response);
+  }
+
+  @Path("/connectionClose")
+  @GET
+  public void testConnectionClose(HttpRequest request, HttpResponder responder) {
+    responder.sendString(HttpResponseStatus.OK, "Close connection", ImmutableMultimap.of("Connection", "close"));
+  }
+
+  @Path("/uploadReject")
+  @POST
+  public BodyConsumer testUploadReject(HttpRequest request, HttpResponder responder) {
+    responder.sendString(HttpResponseStatus.BAD_REQUEST, "Rejected", ImmutableMultimap.of("Connection", "close"));
+    return null;
   }
 
   @Override


### PR DESCRIPTION
User handler can set "Connection: close" header to control closing of the connection after response is sent.
