### PR TITLE
NETTY-7 use exception handlers for streaming methods too

### DIFF
--- a/src/main/java/co/cask/http/BodyConsumer.java
+++ b/src/main/java/co/cask/http/BodyConsumer.java
@@ -39,7 +39,8 @@ public abstract class BodyConsumer {
 
   /**
    * When there is exception on netty while streaming, it will be propagated to handler
-   * so the handler can do the cleanup.
+   * so the handler can do the cleanup. Implementations should not write to an HttpResponder.
+   * Instead, use a {@link ExceptionHandler}.
    * @param cause
    */
   public abstract void handleError(Throwable cause);

--- a/src/main/java/co/cask/http/HttpMethodInfo.java
+++ b/src/main/java/co/cask/http/HttpMethodInfo.java
@@ -24,6 +24,8 @@ import org.jboss.netty.handler.codec.http.HttpChunk;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -34,6 +36,8 @@ import java.lang.reflect.Method;
  * context as attachment.
  */
 class HttpMethodInfo {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HttpMethodInfo.class);
 
   private final Method method;
   private final HttpHandler handler;
@@ -119,6 +123,8 @@ class HttpMethodInfo {
         bodyConsumerError(t);
       } catch (Throwable t2) {
         exceptionHandler.handle(t2, request, responder);
+        // log original throwable since we'll lose it otherwise
+        LOG.debug("Handled exception thrown from handleError. original exception from chunk call was:", t);
         return;
       }
       exceptionHandler.handle(t, request, responder);

--- a/src/main/java/co/cask/http/HttpMethodInfo.java
+++ b/src/main/java/co/cask/http/HttpMethodInfo.java
@@ -115,7 +115,12 @@ class HttpMethodInfo {
     try {
       bodyConsumer.chunk(buffer, responder);
     } catch (Throwable t) {
-      bodyConsumerError(t);
+      try {
+        bodyConsumerError(t);
+      } catch (Throwable t2) {
+        exceptionHandler.handle(t2, request, responder);
+        return;
+      }
       exceptionHandler.handle(t, request, responder);
     }
   }

--- a/src/test/java/co/cask/http/HttpServerTest.java
+++ b/src/test/java/co/cask/http/HttpServerTest.java
@@ -540,6 +540,13 @@ public class HttpServerTest {
     Files.copy(fname, urlConn.getOutputStream());
     Assert.assertEquals(TestHandler.CustomException.HTTP_RESPONSE_STATUS.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
+
+    // exception in body consumer's handleError
+    urlConn = request("/test/v1/stream/customException", HttpMethod.POST);
+    urlConn.setRequestProperty("failOn", "error");
+    Files.copy(fname, urlConn.getOutputStream());
+    Assert.assertEquals(TestHandler.CustomException.HTTP_RESPONSE_STATUS.getCode(), urlConn.getResponseCode());
+    urlConn.disconnect();
   }
 
   protected Socket createRawSocket(URL url) throws IOException {

--- a/src/test/java/co/cask/http/HttpServerTest.java
+++ b/src/test/java/co/cask/http/HttpServerTest.java
@@ -509,7 +509,35 @@ public class HttpServerTest {
 
   @Test
   public void testExceptionHandler() throws IOException {
+    // exception in method
     HttpURLConnection urlConn = request("/test/v1/customException", HttpMethod.POST);
+    Assert.assertEquals(TestHandler.CustomException.HTTP_RESPONSE_STATUS.getCode(), urlConn.getResponseCode());
+    urlConn.disconnect();
+
+    //create a random file to be uploaded.
+    int size = 20 * 1024;
+    File fname = tmpFolder.newFile();
+    RandomAccessFile randf = new RandomAccessFile(fname, "rw");
+    randf.setLength(size);
+    randf.close();
+
+    // exception in streaming method before body consumer is returned
+    urlConn = request("/test/v1/stream/customException", HttpMethod.POST);
+    urlConn.setRequestProperty("failOn", "start");
+    Assert.assertEquals(TestHandler.CustomException.HTTP_RESPONSE_STATUS.getCode(), urlConn.getResponseCode());
+    urlConn.disconnect();
+
+    // exception in body consumer's chunk
+    urlConn = request("/test/v1/stream/customException", HttpMethod.POST);
+    urlConn.setRequestProperty("failOn", "chunk");
+    Files.copy(fname, urlConn.getOutputStream());
+    Assert.assertEquals(TestHandler.CustomException.HTTP_RESPONSE_STATUS.getCode(), urlConn.getResponseCode());
+    urlConn.disconnect();
+
+    // exception in body consumer's onFinish
+    urlConn = request("/test/v1/stream/customException", HttpMethod.POST);
+    urlConn.setRequestProperty("failOn", "finish");
+    Files.copy(fname, urlConn.getOutputStream());
     Assert.assertEquals(TestHandler.CustomException.HTTP_RESPONSE_STATUS.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
   }

--- a/src/test/java/co/cask/http/TestHandler.java
+++ b/src/test/java/co/cask/http/TestHandler.java
@@ -376,7 +376,7 @@ public class TestHandler implements HttpHandler {
   @Path("/stream/customException")
   @POST
   public BodyConsumer testStreamCustomException(HttpRequest request, HttpResponder responder,
-                                                @HeaderParam("failOn") final  String failOn) throws CustomException {
+                                                @HeaderParam("failOn") final String failOn) throws CustomException {
     if ("start".equals(failOn)) {
       throw new CustomException();
     }
@@ -386,6 +386,8 @@ public class TestHandler implements HttpHandler {
       public void chunk(ChannelBuffer request, HttpResponder responder) {
         if ("chunk".equals(failOn)) {
           throw new CustomException();
+        } else if ("error".equals(failOn)) {
+          throw new RuntimeException();
         }
       }
 
@@ -399,6 +401,9 @@ public class TestHandler implements HttpHandler {
 
       @Override
       public void handleError(Throwable cause) {
+        if ("error".equals(failOn)) {
+          throw new CustomException();
+        }
       }
     };
   }


### PR DESCRIPTION
Streaming methods (those that return BodyConsumer) were not using
the exception handler. This fix will catch any throwable from
invoking the method that returns the BodyConsumer, as well as any
throwables from chunk() and finished() calls on the BodyConsumer
itself, and send the throwable to the ExceptionHandler.
