### PR TITLE
(NETTY-12) Only set the responder state to be sent when it’s going to…

### DIFF
--- a/src/main/java/co/cask/http/RequestRouter.java
+++ b/src/main/java/co/cask/http/RequestRouter.java
@@ -134,9 +134,7 @@ public class RequestRouter extends SimpleChannelUpstreamHandler {
   public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e) {
     String exceptionMessage = "Exception caught in channel processing.";
     Throwable cause = e.getCause();
-    if (!exceptionRaised.get()) {
-      exceptionRaised.set(true);
-
+    if (exceptionRaised.compareAndSet(false, true)) {
       if (methodInfo != null) {
         LOG.error(exceptionMessage, cause);
         methodInfo.sendError(HttpResponseStatus.INTERNAL_SERVER_ERROR, cause);


### PR DESCRIPTION
… write to the output channel.
- Also call BodyProducer.onError if exception raised when calling BodyProducer.getContentLength
