### PR TITLE
Allow user to pass in service name for naming threads

### DIFF
--- a/src/test/java/co/cask/http/TestHandler.java
+++ b/src/test/java/co/cask/http/TestHandler.java
@@ -299,7 +299,6 @@ public class TestHandler implements HttpHandler {
       @Override
       public void chunk(ChannelBuffer request, HttpResponder responder) {
         try {
-          System.out.println("chunk received: " + request.readableBytes());
           channel.write(request.toByteBuffer());
         } catch (IOException e) {
           throw Throwables.propagate(e);


### PR DESCRIPTION
- Also removed the long deprecated public constructor.
