### PR TITLE
NETTY-3 Use weighted score to match request URI to destination method

### DIFF
--- a/src/main/java/co/cask/http/HttpResourceHandler.java
+++ b/src/main/java/co/cask/http/HttpResourceHandler.java
@@ -70,6 +70,7 @@ public final class HttpResourceHandler implements HttpHandler {
     this.urlRewriter = urlRewriter;
 
     for (HttpHandler handler : handlers) {
+      LOG.trace("Parsing handler {}", handler.getClass().getName());
       String basePath = "";
       if (handler.getClass().isAnnotationPresent(Path.class)) {
         basePath =  handler.getClass().getAnnotation(Path.class).value();
@@ -89,8 +90,10 @@ public final class HttpResourceHandler implements HttpHandler {
           Set<HttpMethod> httpMethods = getHttpMethods(method);
           Preconditions.checkArgument(httpMethods.size() >= 1,
                                       String.format("No HttpMethod found for method: %s", method.getName()));
-          patternRouter.add(absolutePath, new HttpResourceModel(httpMethods, absolutePath, method,
-                                                                handler, exceptionHandler));
+          HttpResourceModel resourceModel = new HttpResourceModel(httpMethods, absolutePath, method,
+                                                                  handler, exceptionHandler);
+          LOG.trace("Adding resource model {}", resourceModel);
+          patternRouter.add(absolutePath, resourceModel);
         } else {
           LOG.trace("Not adding method {}({}) to path routing like. HTTP calls will not be routed to this method",
                     method.getName(), method.getParameterTypes());

--- a/src/main/java/co/cask/http/HttpResourceHandler.java
+++ b/src/main/java/co/cask/http/HttpResourceHandler.java
@@ -280,40 +280,25 @@ public final class HttpResourceHandler implements HttpHandler {
   getMatchedDestination(List<PatternPathRouterWithGroups.RoutableDestination<HttpResourceModel>> routableDestinations,
                         HttpMethod targetHttpMethod, String requestUri) {
 
+    LOG.trace("Routable destinations for request {}: {}", requestUri, routableDestinations);
     Iterable<String> requestUriParts = Splitter.on('/').omitEmptyStrings().split(requestUri);
     List<PatternPathRouterWithGroups.RoutableDestination<HttpResourceModel>> matchedDestinations =
       Lists.newArrayListWithExpectedSize(routableDestinations.size());
-    int maxExactMatch = 0;
-    int maxGroupMatch = 0;
-    int maxPatternLength = 0;
+    int maxScore = 0;
 
     for (PatternPathRouterWithGroups.RoutableDestination<HttpResourceModel> destination : routableDestinations) {
       HttpResourceModel resourceModel = destination.getDestination();
-      int groupMatch = destination.getGroupNameValues().size();
 
       for (HttpMethod httpMethod : resourceModel.getHttpMethod()) {
         if (targetHttpMethod.equals(httpMethod)) {
-
-          int exactMatch = getExactPrefixMatchCount(
-            requestUriParts, Splitter.on('/').omitEmptyStrings().split(resourceModel.getPath()));
-
-          // When there are multiple matches present, the following precedence order is used -
-          // 1. template path that has highest exact prefix match with the url is chosen.
-          // 2. template path has the maximum groups is chosen.
-          // 3. finally, template path that has the longest length is chosen.
-          if (exactMatch > maxExactMatch) {
-            maxExactMatch = exactMatch;
-            maxGroupMatch = groupMatch;
-            maxPatternLength = resourceModel.getPath().length();
-
+          int score = getWeightedMatchScore(requestUriParts,
+                                            Splitter.on('/').omitEmptyStrings().split(resourceModel.getPath()));
+          LOG.trace("Max score = {}. Weighted score for {} is {}. ", maxScore, destination, score);
+          if (score > maxScore) {
+            maxScore = score;
             matchedDestinations.clear();
             matchedDestinations.add(destination);
-          } else if (exactMatch == maxExactMatch && groupMatch >= maxGroupMatch) {
-            if (groupMatch > maxGroupMatch || resourceModel.getPath().length() > maxPatternLength) {
-              maxGroupMatch = groupMatch;
-              maxPatternLength = resourceModel.getPath().length();
-              matchedDestinations.clear();
-            }
+          } else if (score == maxScore) {
             matchedDestinations.add(destination);
           }
         }
@@ -321,7 +306,8 @@ public final class HttpResourceHandler implements HttpHandler {
     }
 
     if (matchedDestinations.size() > 1) {
-      throw new IllegalStateException(String.format("Multiple matched handlers found for request uri %s", requestUri));
+      throw new IllegalStateException(String.format("Multiple matched handlers found for request uri %s: %s",
+                                                    requestUri, matchedDestinations));
     } else if (matchedDestinations.size() == 1) {
       return matchedDestinations.get(0);
     }
@@ -329,18 +315,29 @@ public final class HttpResourceHandler implements HttpHandler {
   }
 
   /**
-   * @return the number of path components that match from left to right.
+   * Generate a weighted score based on position for matches of URI parts.
+   * The matches are weighted in descending order from left to right.
+   * Exact match is weighted higher than group match, and group match is weighted higher than wildcard match.
+   *
+   * @param requestUriParts the parts of request URI
+   * @param destUriParts the parts of destination URI
+   * @return weighted score
    */
-  private int getExactPrefixMatchCount(Iterable<String> first, Iterable<String> second) {
-    int count = 0;
-    for (Iterator<String> fit = first.iterator(), sit = second.iterator(); fit.hasNext() && sit.hasNext(); ) {
-      if (fit.next().equals(sit.next())) {
-        ++count;
+  private int getWeightedMatchScore(Iterable<String> requestUriParts, Iterable<String> destUriParts) {
+    int score = 0;
+    for (Iterator<String> rit = requestUriParts.iterator(), dit = destUriParts.iterator();
+         rit.hasNext() && dit.hasNext(); ) {
+      String requestPart = rit.next();
+      String destPart = dit.next();
+      if (requestPart.equals(destPart)) {
+        score = (score * 10) + 5;
+      } else if (PatternPathRouterWithGroups.GROUP_PATTERN.matcher(destPart).matches()) {
+        score = (score * 10) + 3;
       } else {
-        break;
+        score = (score * 10) + 1;
       }
     }
-    return count;
+    return score;
   }
 
   @Override

--- a/src/main/java/co/cask/http/HttpResourceHandler.java
+++ b/src/main/java/co/cask/http/HttpResourceHandler.java
@@ -284,15 +284,15 @@ public final class HttpResourceHandler implements HttpHandler {
     Iterable<String> requestUriParts = Splitter.on('/').omitEmptyStrings().split(requestUri);
     List<PatternPathRouterWithGroups.RoutableDestination<HttpResourceModel>> matchedDestinations =
       Lists.newArrayListWithExpectedSize(routableDestinations.size());
-    int maxScore = 0;
+    long maxScore = 0;
 
     for (PatternPathRouterWithGroups.RoutableDestination<HttpResourceModel> destination : routableDestinations) {
       HttpResourceModel resourceModel = destination.getDestination();
 
       for (HttpMethod httpMethod : resourceModel.getHttpMethod()) {
         if (targetHttpMethod.equals(httpMethod)) {
-          int score = getWeightedMatchScore(requestUriParts,
-                                            Splitter.on('/').omitEmptyStrings().split(resourceModel.getPath()));
+          long score = getWeightedMatchScore(requestUriParts,
+                                             Splitter.on('/').omitEmptyStrings().split(resourceModel.getPath()));
           LOG.trace("Max score = {}. Weighted score for {} is {}. ", maxScore, destination, score);
           if (score > maxScore) {
             maxScore = score;
@@ -323,18 +323,18 @@ public final class HttpResourceHandler implements HttpHandler {
    * @param destUriParts the parts of destination URI
    * @return weighted score
    */
-  private int getWeightedMatchScore(Iterable<String> requestUriParts, Iterable<String> destUriParts) {
-    int score = 0;
+  private long getWeightedMatchScore(Iterable<String> requestUriParts, Iterable<String> destUriParts) {
+    long score = 0;
     for (Iterator<String> rit = requestUriParts.iterator(), dit = destUriParts.iterator();
          rit.hasNext() && dit.hasNext(); ) {
       String requestPart = rit.next();
       String destPart = dit.next();
       if (requestPart.equals(destPart)) {
-        score = (score * 10) + 5;
+        score = (score * 5) + 4;
       } else if (PatternPathRouterWithGroups.GROUP_PATTERN.matcher(destPart).matches()) {
-        score = (score * 10) + 3;
+        score = (score * 5) + 3;
       } else {
-        score = (score * 10) + 1;
+        score = (score * 5) + 2;
       }
     }
     return score;

--- a/src/main/java/co/cask/http/PatternPathRouterWithGroups.java
+++ b/src/main/java/co/cask/http/PatternPathRouterWithGroups.java
@@ -40,16 +40,18 @@ public final class PatternPathRouterWithGroups<T> {
   // non-greedy wild card match.
   private static final Pattern WILD_CARD_PATTERN = Pattern.compile("\\*\\*");
 
+  private final int maxPathParts;
   private final List<ImmutablePair<Pattern, RouteDestinationWithGroups>> patternRouteList;
 
-  public static <T> PatternPathRouterWithGroups<T> create() {
-    return new PatternPathRouterWithGroups<>();
+  public static <T> PatternPathRouterWithGroups<T> create(int maxPathParts) {
+    return new PatternPathRouterWithGroups<>(maxPathParts);
   }
 
   /**
    * Initialize PatternPathRouterWithGroups.
    */
-  public PatternPathRouterWithGroups() {
+  public PatternPathRouterWithGroups(int maxPathParts) {
+    this.maxPathParts = maxPathParts;
     this.patternRouteList = Lists.newArrayList();
   }
 
@@ -69,6 +71,10 @@ public final class PatternPathRouterWithGroups<T> {
 
 
     String [] parts = path.split("/");
+    if (parts.length - 1 > maxPathParts) {
+      throw new IllegalArgumentException(String.format("Number of parts of path %s exceeds allowed limit %s",
+                                                       source, maxPathParts));
+    }
     StringBuilder sb =  new StringBuilder();
     List<String> groupNames = Lists.newArrayList();
 

--- a/src/main/java/co/cask/http/PatternPathRouterWithGroups.java
+++ b/src/main/java/co/cask/http/PatternPathRouterWithGroups.java
@@ -35,7 +35,7 @@ public final class PatternPathRouterWithGroups<T> {
 
   //GROUP_PATTERN is used for named wild card pattern in paths which is specified within braces.
   //Example: {id}
-  private static final Pattern GROUP_PATTERN = Pattern.compile("\\{(.*?)\\}");
+  public static final Pattern GROUP_PATTERN = Pattern.compile("\\{(.*?)\\}");
 
   // non-greedy wild card match.
   private static final Pattern WILD_CARD_PATTERN = Pattern.compile("\\*\\*");

--- a/src/test/java/co/cask/http/HttpServerTest.java
+++ b/src/test/java/co/cask/http/HttpServerTest.java
@@ -474,6 +474,17 @@ public class HttpServerTest {
   }
 
   @Test
+  public void testMultiMatchFooBarParamId1() throws Exception {
+    testContent("/test/v1/multi-match/foo/p/bar/baz", "multi-match-foo-param-bar-baz-p");
+  }
+
+  @Test
+  public void testAppVersion() throws Exception {
+    testContent("/test/v1/apps/app1/versions/v1/create", "new");
+    testContent("/test/v1/apps/app1/flows/flow1/start", "old");
+  }
+
+  @Test
   public void testMultiMatchFooPut() throws Exception {
     testContent("/test/v1/multi-match/foo", "multi-match-put-actual-foo", HttpMethod.PUT);
   }

--- a/src/test/java/co/cask/http/PathRouterTest.java
+++ b/src/test/java/co/cask/http/PathRouterTest.java
@@ -31,7 +31,7 @@ public class PathRouterTest {
   @Test
   public void testPathRoutings() {
 
-    PatternPathRouterWithGroups<String> pathRouter = PatternPathRouterWithGroups.create();
+    PatternPathRouterWithGroups<String> pathRouter = PatternPathRouterWithGroups.create(25);
     pathRouter.add("/foo/{baz}/b", "foobarb");
     pathRouter.add("/foo/bar/baz", "foobarbaz");
     pathRouter.add("/baz/bar", "bazbar");
@@ -166,5 +166,11 @@ public class PathRouterTest {
     Assert.assertEquals(1, routes.size());
     Assert.assertEquals("wildcard-foo-id-2", routes.get(0).getDestination());
     Assert.assertEquals(ImmutableMap.of("id", "id1"), routes.get(0).getGroupNameValues());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMaxPathParts() throws Exception {
+    PatternPathRouterWithGroups<String> pathRouter = PatternPathRouterWithGroups.create(5);
+    pathRouter.add("/1/2/3/4/5/6", "max-path-parts");
   }
 }

--- a/src/test/java/co/cask/http/PathRouterTest.java
+++ b/src/test/java/co/cask/http/PathRouterTest.java
@@ -39,6 +39,9 @@ public class PathRouterTest {
     pathRouter.add("/foo/bar", "foobar");
     pathRouter.add("//multiple/slash//route", "multipleslashroute");
 
+    pathRouter.add("/abc/bar", "abc-bar");
+    pathRouter.add("/abc/{type}/{id}", "abc-type-id");
+
     pathRouter.add("/multi/match/**", "multi-match-*");
     pathRouter.add("/multi/match/def", "multi-match-def");
 
@@ -83,6 +86,10 @@ public class PathRouterTest {
     Assert.assertEquals(1, routes.size());
     Assert.assertEquals("foobar", routes.get(0).getDestination());
     Assert.assertTrue(routes.get(0).getGroupNameValues().isEmpty());
+
+    routes = pathRouter.getDestinations("/abc/bar/id");
+    Assert.assertEquals(1, routes.size());
+    Assert.assertEquals("abc-type-id", routes.get(0).getDestination());
 
     routes = pathRouter.getDestinations("/multiple/slash/route");
     Assert.assertEquals(1, routes.size());

--- a/src/test/java/co/cask/http/TestHandler.java
+++ b/src/test/java/co/cask/http/TestHandler.java
@@ -235,6 +235,18 @@ public class TestHandler implements HttpHandler {
     responder.sendString(HttpResponseStatus.OK, "multi-match-foo-bar-param-" + param + "-id-" + id);
   }
 
+  @Path("/apps/{app-id}/versions/{version-id}/create")
+  @GET
+  public void appVersion(HttpRequest request, HttpResponder responder) {
+    responder.sendString(HttpResponseStatus.OK, "new");
+  }
+
+  @Path("/apps/{app-id}/{type}/{id}/{action}")
+  @GET
+  public void appVersionOld(HttpRequest request, HttpResponder responder) {
+    responder.sendString(HttpResponseStatus.OK, "old");
+  }
+
   @Path("/stream/upload")
   @PUT
   public BodyConsumer streamUpload(HttpRequest request, HttpResponder responder) {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/NETTY-3
Build: http://builds.cask.co/browse/NH-BAD3-6

We decided to go with weighted scores for matching request URI parts to destination path parts. The matches are weighted in descending order from left to right. For every match, exact matches have higher weight than group matches, and group matches have higher weight than wildcard matches.
