### PR TITLE
Using isEmpty() instead of peek() to check if task queue is empty, si…

### DIFF
--- a/src/main/java/io/cdap/http/internal/NonStickyEventExecutorGroup.java
+++ b/src/main/java/io/cdap/http/internal/NonStickyEventExecutorGroup.java
@@ -283,7 +283,7 @@ public final class NonStickyEventExecutorGroup implements EventExecutorGroup {
             //
             // The above cases can be distinguished by performing a
             // compareAndSet(NONE, RUNNING). If it returns "false", it is case 1; otherwise it is case 2.
-            if (tasks.peek() == null || !state.compareAndSet(NONE, RUNNING)) {
+            if (tasks.isEmpty() || !state.compareAndSet(NONE, RUNNING)) {
               return; // done
             }
           }


### PR DESCRIPTION
…nce peek() implementation operates in a similar way to poll like a consumer which can lead to a multi-consumer scenario on a multi-producer-single-consumer queue, therefore getting into an infinite loop issue inside MPSC queue implementation.