### PR TITLE
(ISSUE-99) Support flushing chunks response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,8 +145,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <compilerArgs>
             <arg>-Xlint</arg>
           </compilerArgs>

--- a/src/main/java/io/cdap/http/ChunkResponder.java
+++ b/src/main/java/io/cdap/http/ChunkResponder.java
@@ -19,13 +19,14 @@ package io.cdap.http;
 import io.netty.buffer.ByteBuf;
 
 import java.io.Closeable;
+import java.io.Flushable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
  * A responder for sending chunk-encoded response
  */
-public interface ChunkResponder extends Closeable {
+public interface ChunkResponder extends Closeable, Flushable {
 
   /**
    * Adds a chunk of data to the response. The content will be sent to the client asynchronously.
@@ -42,6 +43,14 @@ public interface ChunkResponder extends Closeable {
    * @throws IOException if this {@link ChunkResponder} already closed or the connection is closed
    */
   void sendChunk(ByteBuf chunk) throws IOException;
+
+  /**
+   * Flushes all the chunks writen so far to the client asynchronously.
+   */
+  @Override
+  default void flush() {
+    // no-op
+  }
 
   /**
    * Closes this responder which signals the end of the chunk response.

--- a/src/main/java/io/cdap/http/internal/BasicHttpResponder.java
+++ b/src/main/java/io/cdap/http/internal/BasicHttpResponder.java
@@ -67,11 +67,13 @@ final class BasicHttpResponder extends AbstractHttpResponder {
   private final Channel channel;
   private final AtomicBoolean responded;
   private final boolean sslEnabled;
+  private final int chunkMemoryLimit;
 
-  BasicHttpResponder(Channel channel, boolean sslEnabled) {
+  BasicHttpResponder(Channel channel, boolean sslEnabled, int chunkMemoryLimit) {
     this.channel = channel;
     this.responded = new AtomicBoolean(false);
     this.sslEnabled = sslEnabled;
+    this.chunkMemoryLimit = chunkMemoryLimit;
   }
 
   @Override
@@ -90,7 +92,7 @@ final class BasicHttpResponder extends AbstractHttpResponder {
 
     checkNotResponded();
     channel.write(response);
-    return new ChannelChunkResponder(channel);
+    return new ChannelChunkResponder(channel, chunkMemoryLimit);
   }
 
   @Override

--- a/src/main/java/io/cdap/http/internal/RequestRouter.java
+++ b/src/main/java/io/cdap/http/internal/RequestRouter.java
@@ -81,7 +81,7 @@ public class RequestRouter extends ChannelInboundHandlerAdapter {
         return;
       }
       HttpRequest request = (HttpRequest) msg;
-      BasicHttpResponder responder = new BasicHttpResponder(ctx.channel(), sslEnabled);
+      BasicHttpResponder responder = new BasicHttpResponder(ctx.channel(), sslEnabled, chunkMemoryLimit);
 
       // Reset the methodInfo for the incoming request error handling
       methodInfo = null;

--- a/src/main/java/io/cdap/http/internal/WrappedHttpResponder.java
+++ b/src/main/java/io/cdap/http/internal/WrappedHttpResponder.java
@@ -66,6 +66,11 @@ final class WrappedHttpResponder extends AbstractHttpResponder {
       }
 
       @Override
+      public void flush() {
+        chunkResponder.flush();
+      }
+
+      @Override
       public void close() throws IOException {
         chunkResponder.close();
         runHook(status);

--- a/src/test/java/io/cdap/http/HttpServerTest.java
+++ b/src/test/java/io/cdap/http/HttpServerTest.java
@@ -651,6 +651,19 @@ public class HttpServerTest {
   }
 
   @Test
+  public void testLargeChunkResponse() throws IOException {
+    // Chunk limit for test is 75K, so we request for 150 chunks, each is 1K in length
+    HttpURLConnection urlConn = request("/test/v1/largeChunk?s=1024&n=150", HttpMethod.GET);
+    try {
+      String response = getContent(urlConn);
+      String expected = String.join("", Collections.nCopies(150 * 1024, "0"));
+      Assert.assertEquals(expected, response);
+    } finally {
+      urlConn.disconnect();
+    }
+  }
+
+  @Test
   public void testStringQueryParam() throws IOException {
     // First send without query, for String type, should get defaulted to null.
     testContent("/test/v1/stringQueryParam/mypath", "mypath:null", HttpMethod.GET);

--- a/src/test/java/io/cdap/http/TestHandler.java
+++ b/src/test/java/io/cdap/http/TestHandler.java
@@ -38,6 +38,7 @@ import java.io.PrintStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.concurrent.TimeUnit;
@@ -422,6 +423,19 @@ public class TestHandler extends AbstractHttpHandler {
       chunker.sendChunk(content.readBytes(1));
     }
     chunker.close();
+  }
+
+  @Path("/largeChunk")
+  @GET
+  public void largeChunk(HttpRequest request, HttpResponder responder,
+                         @QueryParam("s") int chunkSize,
+                         @QueryParam("n") int count) throws IOException {
+    String msg = String.join("", Collections.nCopies(chunkSize, "0"));
+    try (ChunkResponder chunker = responder.sendChunkStart(HttpResponseStatus.OK)) {
+      for (int i = 0; i < count; i++) {
+        chunker.sendChunk(StandardCharsets.UTF_8.encode(msg));
+      }
+    }
   }
 
   @Path("/produceBody")


### PR DESCRIPTION
- Upgrade to Java 8
- Use the chunk memory limit setting to automatically flush
- Added a flush method to ChunkResponder as a default method to the interface to be backward compatible