### PR TITLE
Update the EventExecutor behavior

### DIFF
--- a/src/main/java/io/cdap/http/NettyHttpService.java
+++ b/src/main/java/io/cdap/http/NettyHttpService.java
@@ -17,6 +17,8 @@
 package io.cdap.http;
 
 import io.cdap.http.internal.BasicHandlerContext;
+import io.cdap.http.internal.ForwardingEventExecutor;
+import io.cdap.http.internal.ForwardingEventExecutorGroup;
 import io.cdap.http.internal.HttpDispatcher;
 import io.cdap.http.internal.HttpResourceHandler;
 import io.cdap.http.internal.NonStickyEventExecutorGroup;
@@ -37,6 +39,7 @@ import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerKeepAliveHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
+import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
@@ -49,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.RejectedExecutionHandler;
@@ -283,8 +287,9 @@ public final class NettyHttpService {
       return null;
     }
 
+    ThreadGroup threadGroup = new ThreadGroup(serviceName + "-executor-thread");
+
     ThreadFactory threadFactory = new ThreadFactory() {
-      private final ThreadGroup threadGroup = new ThreadGroup(serviceName + "-executor-thread");
       private final AtomicLong count = new AtomicLong(0);
 
       @Override
@@ -301,7 +306,63 @@ public final class NettyHttpService {
       executor.setKeepAliveTime(execThreadKeepAliveSecs, TimeUnit.SECONDS);
       executor.allowCoreThreadTimeOut(true);
     }
-    return new NonStickyEventExecutorGroup(executor);
+
+    // Returns a EventExecutorGroup that overrides the inEventLoop behavior of the EventExecutor returned by the group.
+    // The inEventLoop will return true if it is calling from a thread in the same thread group, hence was created
+    // from the same executor.
+    // This is to make sure channel events coming from a thread owned by the EventExecutor
+    // will be executed in the same thread instead of submitting a new task.
+    return new ForwardingEventExecutorGroup(new NonStickyEventExecutorGroup(executor)) {
+
+      private final EventExecutorGroup group = this;
+
+      @Override
+      public EventExecutor next() {
+        return wrapEventExecutor(super.next());
+      }
+
+      @Override
+      public Iterator<EventExecutor> iterator() {
+        Iterator<EventExecutor> iterator = super.iterator();
+
+        return new Iterator<EventExecutor>() {
+          @Override
+          public boolean hasNext() {
+            return iterator.hasNext();
+          }
+
+          @Override
+          public EventExecutor next() {
+            return wrapEventExecutor(iterator.next());
+          }
+
+          @Override
+          public void remove() {
+            iterator.remove();
+          }
+        };
+      }
+
+      private EventExecutor wrapEventExecutor(EventExecutor executor) {
+        return new ForwardingEventExecutor(executor) {
+
+          @Override
+          public EventExecutorGroup parent() {
+            return group;
+          }
+
+          @Override
+          public boolean inEventLoop() {
+            return inEventLoop(Thread.currentThread());
+          }
+
+          @Override
+          public boolean inEventLoop(Thread thread) {
+            return threadGroup == thread.getThreadGroup();
+          }
+        };
+      }
+    };
   }
 
   /**

--- a/src/main/java/io/cdap/http/internal/ForwardingEventExecutor.java
+++ b/src/main/java/io/cdap/http/internal/ForwardingEventExecutor.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.http.internal;
+
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.ProgressivePromise;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.ScheduledFuture;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A {@link EventExecutor} that forwards all methods to another {@link EventExecutor}.
+ */
+public class ForwardingEventExecutor implements EventExecutor {
+
+  private final EventExecutor delegate;
+
+  public ForwardingEventExecutor(EventExecutor delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public EventExecutor next() {
+    return delegate.next();
+  }
+
+  @Override
+  public EventExecutorGroup parent() {
+    return delegate.parent();
+  }
+
+  @Override
+  public boolean inEventLoop() {
+    return delegate.inEventLoop();
+  }
+
+  @Override
+  public boolean inEventLoop(Thread thread) {
+    return delegate.inEventLoop(thread);
+  }
+
+  @Override
+  public <V> Promise<V> newPromise() {
+    return delegate.newPromise();
+  }
+
+  @Override
+  public <V> ProgressivePromise<V> newProgressivePromise() {
+    return delegate.newProgressivePromise();
+  }
+
+  @Override
+  public <V> Future<V> newSucceededFuture(V v) {
+    return delegate.newSucceededFuture(v);
+  }
+
+  @Override
+  public <V> Future<V> newFailedFuture(Throwable throwable) {
+    return delegate.newFailedFuture(throwable);
+  }
+
+  @Override
+  public boolean isShuttingDown() {
+    return delegate.isShuttingDown();
+  }
+
+  @Override
+  public Future<?> shutdownGracefully() {
+    return delegate.shutdownGracefully();
+  }
+
+  @Override
+  public Future<?> shutdownGracefully(long l, long l1, TimeUnit timeUnit) {
+    return delegate.shutdownGracefully(l, l1, timeUnit);
+  }
+
+  @Override
+  public Future<?> terminationFuture() {
+    return delegate.terminationFuture();
+  }
+
+  @Override
+  @Deprecated
+  public void shutdown() {
+    delegate.shutdown();
+  }
+
+  @Override
+  @Deprecated
+  public List<Runnable> shutdownNow() {
+    return delegate.shutdownNow();
+  }
+
+  @Override
+  public Iterator<EventExecutor> iterator() {
+    return delegate.iterator();
+  }
+
+  @Override
+  public Future<?> submit(Runnable runnable) {
+    return delegate.submit(runnable);
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable runnable, T t) {
+    return delegate.submit(runnable, t);
+  }
+
+  @Override
+  public <T> Future<T> submit(Callable<T> callable) {
+    return delegate.submit(callable);
+  }
+
+  @Override
+  public ScheduledFuture<?> schedule(Runnable runnable, long l, TimeUnit timeUnit) {
+    return delegate.schedule(runnable, l, timeUnit);
+  }
+
+  @Override
+  public <V> ScheduledFuture<V> schedule(Callable<V> callable, long l, TimeUnit timeUnit) {
+    return delegate.schedule(callable, l, timeUnit);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleAtFixedRate(Runnable runnable, long l, long l1, TimeUnit timeUnit) {
+    return delegate.scheduleAtFixedRate(runnable, l, l1, timeUnit);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleWithFixedDelay(Runnable runnable, long l, long l1, TimeUnit timeUnit) {
+    return delegate.scheduleWithFixedDelay(runnable, l, l1, timeUnit);
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return delegate.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return delegate.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return delegate.awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+    throws InterruptedException {
+    return delegate.invokeAll(tasks);
+  }
+
+  @Override
+  public <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> tasks,
+                                                            long timeout, TimeUnit unit) throws InterruptedException {
+    return delegate.invokeAll(tasks, timeout, unit);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+    return delegate.invokeAny(tasks);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+    throws InterruptedException, ExecutionException, TimeoutException {
+    return delegate.invokeAny(tasks, timeout, unit);
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    delegate.execute(command);
+  }
+}

--- a/src/main/java/io/cdap/http/internal/ForwardingEventExecutorGroup.java
+++ b/src/main/java/io/cdap/http/internal/ForwardingEventExecutorGroup.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.http.internal;
+
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.ScheduledFuture;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A {@link EventExecutorGroup} that forwards all methods to another {@link EventExecutorGroup}.
+ */
+public class ForwardingEventExecutorGroup implements EventExecutorGroup {
+
+  private final EventExecutorGroup delegate;
+
+  public ForwardingEventExecutorGroup(EventExecutorGroup delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public boolean isShuttingDown() {
+    return delegate.isShuttingDown();
+  }
+
+  @Override
+  public Future<?> shutdownGracefully() {
+    return delegate.shutdownGracefully();
+  }
+
+  @Override
+  public Future<?> shutdownGracefully(long l, long l1, TimeUnit timeUnit) {
+    return delegate.shutdownGracefully(l, l1, timeUnit);
+  }
+
+  @Override
+  public Future<?> terminationFuture() {
+    return delegate.terminationFuture();
+  }
+
+  @Override
+  @Deprecated
+  public void shutdown() {
+    delegate.shutdown();
+  }
+
+  @Override
+  @Deprecated
+  public List<Runnable> shutdownNow() {
+    return delegate.shutdownNow();
+  }
+
+  @Override
+  public EventExecutor next() {
+    return delegate.next();
+  }
+
+  @Override
+  public Iterator<EventExecutor> iterator() {
+    return delegate.iterator();
+  }
+
+  @Override
+  public Future<?> submit(Runnable runnable) {
+    return delegate.submit(runnable);
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable runnable, T t) {
+    return delegate.submit(runnable, t);
+  }
+
+  @Override
+  public <T> Future<T> submit(Callable<T> callable) {
+    return delegate.submit(callable);
+  }
+
+  @Override
+  public ScheduledFuture<?> schedule(Runnable runnable, long l, TimeUnit timeUnit) {
+    return delegate.schedule(runnable, l, timeUnit);
+  }
+
+  @Override
+  public <V> ScheduledFuture<V> schedule(Callable<V> callable, long l, TimeUnit timeUnit) {
+    return delegate.schedule(callable, l, timeUnit);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleAtFixedRate(Runnable runnable, long l, long l1, TimeUnit timeUnit) {
+    return delegate.scheduleAtFixedRate(runnable, l, l1, timeUnit);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleWithFixedDelay(Runnable runnable, long l, long l1, TimeUnit timeUnit) {
+    return delegate.scheduleWithFixedDelay(runnable, l, l1, timeUnit);
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return delegate.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return delegate.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return delegate.awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+    throws InterruptedException {
+    return delegate.invokeAll(tasks);
+  }
+
+  @Override
+  public <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> tasks,
+                                                            long timeout, TimeUnit unit) throws InterruptedException {
+    return delegate.invokeAll(tasks, timeout, unit);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+    return delegate.invokeAny(tasks);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+    throws InterruptedException, ExecutionException, TimeoutException {
+    return delegate.invokeAny(tasks, timeout, unit);
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    delegate.execute(command);
+  }
+}

--- a/src/main/java/io/cdap/http/internal/ForwardingOrderedEventExecutor.java
+++ b/src/main/java/io/cdap/http/internal/ForwardingOrderedEventExecutor.java
@@ -19,6 +19,7 @@ package io.cdap.http.internal;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.OrderedEventExecutor;
 import io.netty.util.concurrent.ProgressivePromise;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.ScheduledFuture;
@@ -32,13 +33,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * A {@link EventExecutor} that forwards all methods to another {@link EventExecutor}.
+ * An {@link OrderedEventExecutor} that forwards all methods to another {@link OrderedEventExecutor}.
  */
-public class ForwardingEventExecutor implements EventExecutor {
+public class ForwardingOrderedEventExecutor implements OrderedEventExecutor {
 
-  private final EventExecutor delegate;
+  private final OrderedEventExecutor delegate;
 
-  public ForwardingEventExecutor(EventExecutor delegate) {
+  public ForwardingOrderedEventExecutor(OrderedEventExecutor delegate) {
     this.delegate = delegate;
   }
 

--- a/src/test/java/io/cdap/http/ExecutorThreadPoolTest.java
+++ b/src/test/java/io/cdap/http/ExecutorThreadPoolTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.concurrent.EventExecutor;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * Unit test for testing the threading behavior when {@link NettyHttpService.Builder#setExecThreadPoolSize(int)} is
+ * set to non-zero.
+ */
+public class ExecutorThreadPoolTest {
+
+  @Test
+  public void testSameEventThread() throws Exception {
+    AtomicReference<Thread> handlerThread = new AtomicReference<>();
+
+    NettyHttpService httpService = NettyHttpService.builder("test")
+      .setExecThreadPoolSize(5)
+      .setHttpHandlers(new TestHandler(handlerThread))
+      .setChannelPipelineModifier(new ChannelPipelineModifier() {
+        @Override
+        public void modify(ChannelPipeline pipeline) {
+          // Modify the pipeline to insert a handler before the dispatcher with the same EventExecutor
+          // This is to test the invocation of the dispatcher would always be in the same thread
+          // as the handler inserted before it.
+          EventExecutor executor = pipeline.context("dispatcher").executor();
+          pipeline.addBefore(executor, "dispatcher", "authenticator", new TestChannelHandler(handlerThread));
+        }
+      })
+      .build();
+
+    httpService.start();
+    try {
+      InetSocketAddress addr = httpService.getBindAddress();
+      URL url = new URL(String.format("http://%s:%d/upload", addr.getHostName(), addr.getPort()));
+      HttpURLConnection urlConn = (HttpURLConnection) url.openConnection();
+      try {
+        urlConn.setRequestMethod("POST");
+        urlConn.setDoOutput(true);
+        urlConn.setChunkedStreamingMode(32);
+
+        // The NonStickyEventExecutorGroup has max run of 1024. So we create a data of size > 32K.
+        String data = String.join("", Collections.nCopies(32768, "0123456789"));
+        try (OutputStream os = urlConn.getOutputStream()) {
+          os.write(data.getBytes(StandardCharsets.UTF_8));
+        }
+
+        Assert.assertEquals(HttpURLConnection.HTTP_OK, urlConn.getResponseCode());
+      } finally {
+        urlConn.disconnect();
+      }
+    } finally {
+      httpService.stop();
+    }
+  }
+
+  /**
+   * A {@link ChannelHandler} for testing executor thread behavior.
+   */
+  private static final class TestChannelHandler extends ChannelInboundHandlerAdapter {
+
+    private final AtomicReference<Thread> handlerThread;
+
+    private TestChannelHandler(AtomicReference<Thread> handlerThread) {
+      this.handlerThread = handlerThread;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+      handlerThread.set(Thread.currentThread());
+      super.channelRead(ctx, msg);
+    }
+  }
+
+  /**
+   * Test handler for testing executor thread behavior.
+   */
+  public static final class TestHandler extends AbstractHttpHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestHandler.class);
+
+    private final AtomicReference<Thread> handlerThread;
+
+    public TestHandler(AtomicReference<Thread> handlerThread) {
+      this.handlerThread = handlerThread;
+    }
+
+    @POST
+    @Path("/upload")
+    public BodyConsumer upload(HttpRequest request, HttpResponder responder) {
+      if (!Thread.currentThread().equals(handlerThread.get())) {
+        responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+        return null;
+      }
+
+      return new BodyConsumer() {
+        @Override
+        public void chunk(ByteBuf request, HttpResponder responder) {
+          if (!Thread.currentThread().equals(handlerThread.get())) {
+            responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+            throw new IllegalStateException("Wrong thread " + Thread.currentThread() + " " + handlerThread.get());
+          }
+        }
+
+        @Override
+        public void finished(HttpResponder responder) {
+          if (Thread.currentThread().equals(handlerThread.get())) {
+            responder.sendStatus(HttpResponseStatus.OK);
+          } else {
+            responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+          }
+        }
+
+        @Override
+        public void handleError(Throwable cause) {
+          LOG.error("Exception raised", cause);
+        }
+      };
+    }
+  }
+}


### PR DESCRIPTION
- Make sure ChannelHandler events firing from the same EventExecutor as the next pipeline state are called from within the same thread