### PR TITLE
Add exit gate

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,4 +1,4 @@
-# Copyright © 2022 Cask Data, Inc.
+# Copyright © 2025 Cask Data, Inc.
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
 #  the License at
@@ -25,15 +25,6 @@ jobs:
         branch: [ develop ]
 
     steps:
-      - name: Get Secrets from GCP Secret Manager
-        id: 'secrets'
-        uses: 'google-github-actions/get-secretmanager-secrets@v0'
-        with:
-          secrets: |-
-            CDAP_OSSRH_USERNAME:cdapio-github-builds/CDAP_OSSRH_USERNAME
-            CDAP_OSSRH_PASSWORD:cdapio-github-builds/CDAP_OSSRH_PASSWORD
-            CDAP_GPG_PASSPHRASE:cdapio-github-builds/CDAP_GPG_PASSPHRASE
-            CDAP_GPG_PRIVATE_KEY:cdapio-github-builds/CDAP_GPG_PRIVATE_KEY
 
       - name: Recursively Checkout Repository
         uses: actions/checkout@v3
@@ -50,22 +41,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-${{ github.workflow }}
 
-      - name: Set up GPG conf
+      - name: 'Submit Build to Google Cloud Build'
+        id: gcb
+        working-directory: netty-http
         run: |
-          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
-          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
-
-      - name: Import GPG key
+      - name: Submit Build to GCB
+        id: gcb
+        working-directory: cdap-e2e-tests
         run: |
-          echo "$GPG_PRIVATE_KEY" > private.key
-          gpg --import --batch private.key
-        env:
-          GPG_PRIVATE_KEY: ${{ steps.secrets.outputs.CDAP_GPG_PRIVATE_KEY }}
-
-      - name: Deploy Maven
-        working-directory: netty
-        run: mvn -U clean deploy -P release -Dgpg.passphrase=$CDAP_GPG_PASSPHRASE
-        env:
-          CDAP_OSSRH_USERNAME: ${{ steps.secrets.outputs.CDAP_OSSRH_USERNAME }}
-          CDAP_OSSRH_PASSWORD: ${{ steps.secrets.outputs.CDAP_OSSRH_PASSWORD }}
-          CDAP_GPG_PASSPHRASE: ${{ steps.secrets.outputs.CDAP_GPG_PASSPHRASE }}
+          gcloud builds submit . \
+            --config=cloudbuild.yaml \
+            --project='cdapio-github-builds' 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,66 @@
+# Copyright © 2025 Cask Data, Inc.
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+steps:
+  - name: 'gcr.io/cloud-builders/mvn:3.8-jdk-8'
+    id: maven-package
+    entrypoint: 'mvn'
+    args:
+      - -B
+      - -U
+      - clean
+      - package
+      - -DskipTests
+
+  - name: 'gcr.io/cloud-builders/mvn:3.8-jdk-8'
+    id: deploy-to-artifact-registry
+    entrypoint: 'mvn'
+    args:
+      - 'deploy'
+      - '-Dmaven.wagon.http.google.EffectiveVersion=1.0.1'
+    waitFor: ['maven-package']
+
+  - name: 'bash'
+    id: create-exit-gate-manifest
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -e
+        MANIFEST_FILE="/workspace/exit_gate_manifest.textproto"
+        echo '# -*- protobuffer -*-' > "$${MANIFEST_FILE}"
+        echo '# proto-file: security/opensource/exit_gate_v1/onboarded/proto/publishing_manifest.proto' >> "$${MANIFEST_FILE}"
+        echo '# proto-message: PublishingManifest' >> "$${MANIFEST_FILE}"
+        echo '' >> "$${MANIFEST_FILE}"
+        echo 'publish_all: true' >> "$${MANIFEST_FILE}"
+        echo "Created manifest file: $${MANIFEST_FILE}"
+    waitFor: ['deploy-to-artifact-registry']
+
+  - name: 'gcr.io/cloud-builders/gsutil'
+    id: upload-exit-gate-manifest
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -e
+        GCS_MANIFEST_DIR="gs://oss-exit-gate-prod-projects-bucket/cloud-data-fusion/mavencentral/manifests/"
+        MANIFEST_FILE="/workspace/exit_gate_manifest.textproto"
+        # Use a timestamp to create a unique manifest filename for each release
+        MANIFEST_FILENAME="release_$(date -u +%Y%m%d%H%M%S).textproto"
+
+        echo "Uploading manifest to $${GCS_MANIFEST_DIR}$${MANIFEST_FILENAME}"
+        gsutil cp "$${MANIFEST_FILE}" "$${GCS_MANIFEST_DIR}$${MANIFEST_FILENAME}"
+        echo "Manifest uploaded successfully. OSS Exit Gate process should now be triggered."
+    waitFor: ['create-exit-gate-manifest']
+
+options:
+  requestedVerifyOption: VERIFIED
+  machineType: 'E2_HIGHCPU_32'

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,30 @@
     <gson.version>2.2.4</gson.version>
   </properties>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>artifact-registry</id>
+      <url>artifactregistry://us-maven.pkg.dev/oss-exit-gate-prod/cloud-data-fusion--mavencentral</url>
+    </snapshotRepository>
+    <repository>
+      <id>artifact-registry</id>
+      <url>artifactregistry://us-maven.pkg.dev/oss-exit-gate-prod/cloud-data-fusion--mavencentral</url>
+    </repository>
+  </distributionManagement>
+
+  <repositories>
+    <repository>
+      <id>artifact-registry</id>
+      <url>artifactregistry:us-maven.pkg.dev/oss-exit-gate-prod/cloud-data-fusion--mavencentral</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>javax.ws.rs</groupId>
@@ -128,6 +152,13 @@
   </dependencies>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>com.google.cloud.artifactregistry</groupId>
+        <artifactId>artifactregistry-maven-wagon</artifactId>
+        <version>2.2.5</version>
+      </extension>
+    </extensions>
     <plugins>
       <!-- Compiler -->
       <plugin>
@@ -342,38 +373,6 @@
                 </execution>
               </executions>
             </plugin>
-
-            <!-- GPG signature -->
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-gpg-plugin</artifactId>
-              <version>1.5</version>
-              <configuration>
-                <passphrase>${gpg.passphrase}</passphrase>
-                <useAgent>${gpg.useagent}</useAgent>
-              </configuration>
-              <executions>
-                <execution>
-                  <goals>
-                    <goal>sign</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
-
-            <!-- Nexus deploy plugin -->
-            <plugin>
-              <groupId>org.sonatype.central</groupId>
-              <artifactId>central-publishing-maven-plugin</artifactId>
-              <version>0.8.0</version>
-              <extensions>true</extensions>
-              <configuration>
-                <publishingServerId>sonatype.release</publishingServerId>
-                <autoPublish>false</autoPublish>
-                <ignorePublishedComponents>true</ignorePublishedComponents>
-              </configuration>
-            </plugin>
-
           </plugins>
         </pluginManagement>
 
@@ -392,10 +391,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.5</version>
-          </plugin>
-          <plugin>
-            <groupId>org.sonatype.central</groupId>
-            <artifactId>central-publishing-maven-plugin</artifactId>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
 This change refactors the build process to improve artifact security and provenance.

## Key Changes:

Maven artifact building  and attestations are now performed within GCB.
Release artifacts, and build attestations are staged in a designated bucket.
This new process enhances the security and verifiability of the build supply chain.